### PR TITLE
Added basic nosurf wrapper and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ to other middleware are encouraged.
 | [Gorilla logger](https://github.com/gorilla/handlers) | [Gorilla log example](https://github.com/carbocation/interpose/blob/master/examples/gorillalog/main.go) | [Gorilla team](https://github.com/gorilla/) | Gorilla Apache CombinedLogger |
 | [Logrus](https://github.com/meatballhat/negroni-logrus) | [Logrus example](https://github.com/carbocation/interpose/blob/master/examples/adaptors/logrus/main.go) | [Dan Buch](https://github.com/meatballhat) | Logrus-based logger, also demonstrating how Negroni packages can be used in Interpose |
 | [Buffered output](https://github.com/goods/httpbuf) | [Buffer example](https://github.com/carbocation/interpose/blob/master/examples/buffer/main.go) | [zeebo](https://github.com/zeebo) | Output buffering demonstrating how headers can be written after HTTP body is sent |
+| [nosurf](https://github.com/justinas/nosurf) | [nosurf example](https://github.com/carbocation/interpose/blob/master/examples/nosurf/main.go) | [justinas](https://github.com/justinas) | A CSRF protection middleware for Go. |
 
 ## Adaptors
 

--- a/examples/nosurf/main.go
+++ b/examples/nosurf/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"html/template"
+	"net/http"
+	"time"
+
+	"github.com/carbocation/interpose"
+	"github.com/carbocation/interpose/middleware"
+	"github.com/gorilla/mux"
+	"github.com/justinas/nosurf"
+	"github.com/stretchr/graceful"
+)
+
+var templ = template.Must(template.New("t1").Parse(`
+<!doctype html>
+<html>
+<body>
+{{ if .name }}
+<p>Your name: {{ .name }}</p>
+{{ end }}
+<form action="/" method="POST">
+<input type="text" name="name">
+
+<!-- Try removing this or changing its value
+     and see what happens -->
+<input type="hidden" name="csrf_token" value="{{ .token }}">
+<input type="submit" value="Send">
+</form>
+</body>
+</html>
+`))
+
+func main() {
+	router := mux.NewRouter()
+
+	router.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		context := make(map[string]string)
+		context["token"] = nosurf.Token(req)
+		if req.Method == "POST" {
+			context["name"] = req.FormValue("name")
+		}
+
+		templ.Execute(w, context)
+	})
+
+	mw := interpose.New()
+
+	// Apply the router.
+	mw.UseHandler(router)
+	mw.Use(middleware.Nosurf())
+
+	// Launch and permit graceful shutdown, allowing up to 10 seconds for existing
+	// connections to end
+	graceful.Run(":3001", 10*time.Second, mw)
+}

--- a/middleware/nosurf.go
+++ b/middleware/nosurf.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/justinas/nosurf"
+)
+
+// Nosurf is a wrapper for justinas' csrf protection middleware
+func Nosurf() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return nosurf.New(next)
+	}
+}


### PR DESCRIPTION
This is just a bare minimum example of using justinas/nosurf.

I think, we should at least add an optional `http.Handler` argument to pass to `SetFailureHandler()` but i'm not too sure how we should handle the whole `Exempt*()` thing. Maybe better add another example and/or documentation, that nosurf has to be setup by the dev if he needs full fledged excempt support.
