### PR TITLE
gorilla/context - don't leave old requests in the map

### DIFF
--- a/examples/basicAuthFunc/main.go
+++ b/examples/basicAuthFunc/main.go
@@ -46,5 +46,5 @@ func main() {
 
 	router.Methods("GET").PathPrefix("/protected").Handler(protectedMiddlew)
 
-	http.ListenAndServe(":3001", middle)
+	http.ListenAndServe(":3001", context.ClearHandler(middle))
 }

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -47,5 +47,5 @@ func main() {
 
 	// Launch and permit graceful shutdown, allowing up to 10 seconds for existing
 	// connections to end
-	graceful.Run(":3001", 10*time.Second, mw)
+	graceful.Run(":3001", 10*time.Second, context.ClearHandler(mw))
 }

--- a/examples/menagerie/ascendinginteger.go
+++ b/examples/menagerie/ascendinginteger.go
@@ -49,5 +49,5 @@ func main() {
 		}
 	}())
 
-	http.ListenAndServe(":3001", middle)
+	http.ListenAndServe(":3001", context.ClearHandler(middle))
 }


### PR DESCRIPTION
Hi,

after reading [this](https://elithrar.github.io/article/map-string-interface/) article on different context passing techniques I noticed that we had this problem in the examples. From the article:

> The downsides? The global map and its mutexes may result in contention at high loads, and you need to call context.Clear() at the end of every request (i.e. on each handler). Forget to do that (or wrap your top-level server handler) and you'll open yourself up to a memory leak where old requests remain in the map. If you're writing middleware that uses gorilla/context, then you need to make sure your package user imports context calls context.ClearHandler on their handlers/router.
