### PR TITLE
Update Negroni references

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Some frameworks that are not strictly `http.Handler` compliant use middleware th
 can be readily converted into Interpose-compliant middleware. So far, adaptors for 
 Martini and Negroni have been created. 
 
-For example, to use github.com/codegangsta/negroni middleware in Interpose, you 
+For example, to use github.com/urfave/negroni middleware in Interpose, you 
 can use `adaptors.FromNegroni`:
 
 ```go

--- a/adaptors/negroni.go
+++ b/adaptors/negroni.go
@@ -3,7 +3,7 @@ package adaptors
 import (
 	"net/http"
 
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 )
 
 func FromNegroni(handler negroni.Handler) func(http.Handler) http.Handler {

--- a/examples/adaptors/logrus/main.go
+++ b/examples/adaptors/logrus/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/carbocation/interpose"
 	"github.com/carbocation/interpose/adaptors"
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/gorilla/mux"
 	"github.com/meatballhat/negroni-logrus"
 	"github.com/stretchr/graceful"


### PR DESCRIPTION
Negroni has been renamed from `github.com/codegangsta/negroni` to `github.com/urfave/negroni`. 

Updating the references to reflect this for the adaptors. 
