### PR TITLE
Update broken negroni dependency

### DIFF
--- a/adaptors/negroni.go
+++ b/adaptors/negroni.go
@@ -3,7 +3,7 @@ package adaptors
 import (
 	"net/http"
 
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 )
 
 func FromNegroni(handler negroni.Handler) func(http.Handler) http.Handler {


### PR DESCRIPTION
This repo is using an old version of negroni, resulting in some issues:

https://github.com/meatballhat/negroni-logrus/issues/24
https://github.com/urfave/negroni/issues/159

The new repo must be used to avoid conflicts.